### PR TITLE
Use cuBLAS in matrixMulAdd example

### DIFF
--- a/example/matrixMulAdd/CMakeLists.txt
+++ b/example/matrixMulAdd/CMakeLists.txt
@@ -10,6 +10,9 @@ set(_TARGET_NAME matrixMulAdd)
 
 project(${_TARGET_NAME} LANGUAGES CXX)
 
+find_package(CUDA REQUIRED)
+set(CUDA_LIBRARIES ${CUDA_LIBRARIES} cublas)
+
 if(NOT TARGET alpaka::alpaka)
     option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
     if(alpaka_USE_SOURCE_TREE)
@@ -26,7 +29,7 @@ alpaka_add_executable(
 
 target_link_libraries(
     ${_TARGET_NAME}
-    PUBLIC alpaka::alpaka)
+    PUBLIC alpaka::alpaka ${CUDA_LIBRARIES})
 
 set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER example)
 

--- a/example/matrixMulAdd/src/matrixMulAdd.cpp
+++ b/example/matrixMulAdd/src/matrixMulAdd.cpp
@@ -1,25 +1,11 @@
 #include <alpaka/alpaka.hpp>
 #include <alpaka/example/ExecuteForEachAccTag.hpp>
 
+#include <cublas_v2.h>
 #include <chrono>
 #include <iostream>
+#include <cstdlib>
 
-//! Kernel performing multiplication of two fixed 2x2 matrices
-struct MatrixMulKernel
-{
-    template<typename TAcc, typename T>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, T const* A, T const* B, T* C) const
-    {
-        auto const idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0];
-        if(idx < 4)
-        {
-            auto const row = idx / 2;
-            auto const col = idx % 2;
-            T sum = A[row * 2 + 0] * B[0 * 2 + col] + A[row * 2 + 1] * B[1 * 2 + col];
-            C[idx] = sum;
-        }
-    }
-};
 
 //! Kernel summing all four elements of a 2x2 matrix
 struct SumKernel
@@ -37,7 +23,7 @@ struct SumKernel
 };
 
 template<alpaka::concepts::Tag TAccTag>
-auto example(TAccTag const&) -> int
+auto example(TAccTag const&, int iterations) -> int
 {
     using Dim = alpaka::DimInt<1>;
     using Idx = std::size_t;
@@ -64,71 +50,141 @@ auto example(TAccTag const&) -> int
 
     BufHost bufHostA(alpaka::allocBuf<Data, Idx>(devHost, extent));
     BufHost bufHostB(alpaka::allocBuf<Data, Idx>(devHost, extent));
-    BufHost bufHostC(alpaka::allocBuf<Data, Idx>(devHost, extent));
-    BufHost bufHostSum(alpaka::allocBuf<Data, Idx>(devHost, alpaka::Vec<Dim, Idx>(1)));
+    BufHost bufHostC1(alpaka::allocBuf<Data, Idx>(devHost, extent));
+    BufHost bufHostC2(alpaka::allocBuf<Data, Idx>(devHost, extent));
+    BufHost bufHostSum1(alpaka::allocBuf<Data, Idx>(devHost, alpaka::Vec<Dim, Idx>(1)));
+    BufHost bufHostSum2(alpaka::allocBuf<Data, Idx>(devHost, alpaka::Vec<Dim, Idx>(1)));
 
     // initialize 2x2 matrices
     bufHostA[0] = 1.f; bufHostA[1] = 2.f; bufHostA[2] = 3.f; bufHostA[3] = 4.f;
     bufHostB[0] = 5.f; bufHostB[1] = 6.f; bufHostB[2] = 7.f; bufHostB[3] = 8.f;
-    bufHostC[0] = bufHostC[1] = bufHostC[2] = bufHostC[3] = 0.f;
-    bufHostSum[0] = 0.f;
+    bufHostC1[0] = bufHostC1[1] = bufHostC1[2] = bufHostC1[3] = 0.f;
+    bufHostC2[0] = bufHostC2[1] = bufHostC2[2] = bufHostC2[3] = 0.f;
+    bufHostSum1[0] = 0.f;
+    bufHostSum2[0] = 0.f;
 
     BufAcc bufAccA(alpaka::allocBuf<Data, Idx>(devAcc, extent));
     BufAcc bufAccB(alpaka::allocBuf<Data, Idx>(devAcc, extent));
-    BufAcc bufAccC(alpaka::allocBuf<Data, Idx>(devAcc, extent));
-    BufAcc bufAccSum(alpaka::allocBuf<Data, Idx>(devAcc, alpaka::Vec<Dim, Idx>(1)));
+    BufAcc bufAccC1(alpaka::allocBuf<Data, Idx>(devAcc, extent));
+    BufAcc bufAccC2(alpaka::allocBuf<Data, Idx>(devAcc, extent));
+    BufAcc bufAccSum1(alpaka::allocBuf<Data, Idx>(devAcc, alpaka::Vec<Dim, Idx>(1)));
+    BufAcc bufAccSum2(alpaka::allocBuf<Data, Idx>(devAcc, alpaka::Vec<Dim, Idx>(1)));
 
     alpaka::memcpy(queue, bufAccA, bufHostA);
     alpaka::memcpy(queue, bufAccB, bufHostB);
-    alpaka::memcpy(queue, bufAccC, bufHostC);
-    alpaka::memcpy(queue, bufAccSum, bufHostSum);
+    alpaka::memcpy(queue, bufAccC1, bufHostC1);
+    alpaka::memcpy(queue, bufAccC2, bufHostC2);
+    alpaka::memcpy(queue, bufAccSum1, bufHostSum1);
+    alpaka::memcpy(queue, bufAccSum2, bufHostSum2);
 
-    MatrixMulKernel mulKernel;
     SumKernel sumKernel;
 
-    alpaka::KernelCfg<Acc> cfgMul = {extent, Idx{1}};
-    auto const workDivMul = alpaka::getValidWorkDiv(cfgMul, devAcc, mulKernel, alpaka::getPtrNative(bufAccA), alpaka::getPtrNative(bufAccB), alpaka::getPtrNative(bufAccC));
-
     alpaka::KernelCfg<Acc> cfgSum = {alpaka::Vec<Dim, Idx>(1), Idx{1}};
-    auto const workDivSum = alpaka::getValidWorkDiv(cfgSum, devAcc, sumKernel, alpaka::getPtrNative(bufAccC), alpaka::getPtrNative(bufAccSum));
+    auto const workDivSum = alpaka::getValidWorkDiv(cfgSum, devAcc, sumKernel, alpaka::getPtrNative(bufAccC1), alpaka::getPtrNative(bufAccSum1));
 
-    auto const startTotal = std::chrono::high_resolution_clock::now();
+    auto stream = alpaka::getNativeHandle(queue);
+    cublasHandle_t handle;
+    cublasCreate(&handle);
+    cublasSetStream(handle, stream);
 
-    // multiplication kernel
+    double totalMul1 = 0.0, totalAdd1 = 0.0, totalMul2 = 0.0, totalAdd2 = 0.0, totalRuntime = 0.0;
+
+    for(int i = 0; i < iterations; ++i)
+    {
+        auto startTotal = std::chrono::high_resolution_clock::now();
+
+        alpaka::wait(queue);
+        auto startMul1 = std::chrono::high_resolution_clock::now();
+        float alpha1 = 1.0f, beta = 0.0f;
+        cublasSgemm(handle,
+                    CUBLAS_OP_N,
+                    CUBLAS_OP_N,
+                    2,
+                    2,
+                    2,
+                    &alpha1,
+                    alpaka::getPtrNative(bufAccA),
+                    2,
+                    alpaka::getPtrNative(bufAccB),
+                    2,
+                    &beta,
+                    alpaka::getPtrNative(bufAccC1),
+                    2);
+        alpaka::wait(queue);
+        auto endMul1 = std::chrono::high_resolution_clock::now();
+
+        auto startAdd1 = std::chrono::high_resolution_clock::now();
+        alpaka::exec<Acc>(queue, workDivSum, sumKernel, alpaka::getPtrNative(bufAccC1), alpaka::getPtrNative(bufAccSum1));
+        alpaka::wait(queue);
+        auto endAdd1 = std::chrono::high_resolution_clock::now();
+
+        alpaka::memcpy(queue, bufHostSum1, bufAccSum1);
+        alpaka::wait(queue);
+        float alpha2 = bufHostSum1[0];
+
+        auto startMul2 = std::chrono::high_resolution_clock::now();
+        cublasSgemm(handle,
+                    CUBLAS_OP_N,
+                    CUBLAS_OP_N,
+                    2,
+                    2,
+                    2,
+                    &alpha2,
+                    alpaka::getPtrNative(bufAccA),
+                    2,
+                    alpaka::getPtrNative(bufAccB),
+                    2,
+                    &beta,
+                    alpaka::getPtrNative(bufAccC2),
+                    2);
+        alpaka::wait(queue);
+        auto endMul2 = std::chrono::high_resolution_clock::now();
+
+        auto startAdd2 = std::chrono::high_resolution_clock::now();
+        alpaka::exec<Acc>(queue, workDivSum, sumKernel, alpaka::getPtrNative(bufAccC2), alpaka::getPtrNative(bufAccSum2));
+        alpaka::wait(queue);
+        auto endAdd2 = std::chrono::high_resolution_clock::now();
+
+        auto endTotal = std::chrono::high_resolution_clock::now();
+
+        totalMul1 += std::chrono::duration<double>(endMul1 - startMul1).count();
+        totalAdd1 += std::chrono::duration<double>(endAdd1 - startAdd1).count();
+        totalMul2 += std::chrono::duration<double>(endMul2 - startMul2).count();
+        totalAdd2 += std::chrono::duration<double>(endAdd2 - startAdd2).count();
+        totalRuntime += std::chrono::duration<double>(endTotal - startTotal).count();
+    }
+
+    alpaka::memcpy(queue, bufHostC1, bufAccC1);
+    alpaka::memcpy(queue, bufHostC2, bufAccC2);
+    alpaka::memcpy(queue, bufHostSum1, bufAccSum1);
+    alpaka::memcpy(queue, bufHostSum2, bufAccSum2);
     alpaka::wait(queue);
-    auto startMul = std::chrono::high_resolution_clock::now();
-    alpaka::exec<Acc>(queue, workDivMul, mulKernel, alpaka::getPtrNative(bufAccA), alpaka::getPtrNative(bufAccB), alpaka::getPtrNative(bufAccC));
-    alpaka::wait(queue);
-    auto endMul = std::chrono::high_resolution_clock::now();
 
-    // addition kernel
-    auto startAdd = std::chrono::high_resolution_clock::now();
-    alpaka::exec<Acc>(queue, workDivSum, sumKernel, alpaka::getPtrNative(bufAccC), alpaka::getPtrNative(bufAccSum));
-    alpaka::wait(queue);
-    auto endAdd = std::chrono::high_resolution_clock::now();
+    cublasDestroy(handle);
 
-    alpaka::memcpy(queue, bufHostC, bufAccC);
-    alpaka::memcpy(queue, bufHostSum, bufAccSum);
-    alpaka::wait(queue);
+    std::cout << "Average time GEMM1: " << totalMul1 / iterations << "s" << std::endl;
+    std::cout << "Average time Add1: " << totalAdd1 / iterations << "s" << std::endl;
+    std::cout << "Average time GEMM2: " << totalMul2 / iterations << "s" << std::endl;
+    std::cout << "Average time Add2: " << totalAdd2 / iterations << "s" << std::endl;
+    std::cout << "Average total time: " << totalRuntime / iterations << "s" << std::endl;
 
-    auto endTotal = std::chrono::high_resolution_clock::now();
-
-    std::cout << "Time for multiplication: " << std::chrono::duration<double>(endMul - startMul).count() << "s" << std::endl;
-    std::cout << "Time for addition: " << std::chrono::duration<double>(endAdd - startAdd).count() << "s" << std::endl;
-    std::cout << "Total time: " << std::chrono::duration<double>(endTotal - startTotal).count() << "s" << std::endl;
-
-    std::cout << "Result matrix:" << std::endl;
-    std::cout << bufHostC[0] << " " << bufHostC[1] << std::endl;
-    std::cout << bufHostC[2] << " " << bufHostC[3] << std::endl;
-    std::cout << "Sum of result elements: " << bufHostSum[0] << std::endl;
+    std::cout << "Result matrix after GEMM2:" << std::endl;
+    std::cout << bufHostC2[0] << " " << bufHostC2[1] << std::endl;
+    std::cout << bufHostC2[2] << " " << bufHostC2[3] << std::endl;
+    std::cout << "Sum1: " << bufHostSum1[0] << ", Sum2: " << bufHostSum2[0] << std::endl;
 
     return EXIT_SUCCESS;
 }
 
-int main()
+int main(int argc, char* argv[])
 {
+    int iterations = 100;
+    if(argc > 1)
+    {
+        iterations = std::atoi(argv[1]);
+    }
     std::cout << "Check enabled accelerator tags:" << std::endl;
     alpaka::printTagNames<alpaka::EnabledAccTags>();
-    return alpaka::executeForEachAccTag([=](auto const& tag) { return example(tag); });
+    return alpaka::executeForEachAccTag([=](auto const& tag) { return example(tag, iterations); });
 }
 


### PR DESCRIPTION
## Summary
- use cuBLAS in `matrixMulAdd` example instead of a custom multiplication kernel
- loop GEMM and addition steps multiple times and report average runtimes
- allow iteration count via command line argument
- link cuBLAS in the example CMake configuration

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_68518078d7f0832eadb36a3bf4e28787